### PR TITLE
[FIX] #47509 fix project company required to False

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -160,7 +160,7 @@ class Project(models.Model):
         help="If the active field is set to False, it will allow you to hide the project without removing it.")
     sequence = fields.Integer(default=10, help="Gives the sequence order when displaying a list of Projects.")
     partner_id = fields.Many2one('res.partner', string='Customer', auto_join=True, tracking=True, domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
-    company_id = fields.Many2one('res.company', string='Company', required=True, default=lambda self: self.env.company)
+    company_id = fields.Many2one('res.company', string='Company', required=False, default=lambda self: self.env.company)
     currency_id = fields.Many2one('res.currency', related="company_id.currency_id", string="Currency", readonly=True)
     analytic_account_id = fields.Many2one('account.analytic.account', string="Analytic Account", copy=False, ondelete='set null',
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", check_company=True,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Le champ company_id des projects templates est réinitialisé automatiquement après la mise en production si sa valeur est vide. Cela est dû à la mise à jour du module project natif, où le champ company_id (ayant required=True) calcule automatiquement sa valeur par défaut avec default=self.env.company s'il est vide.

Current behavior before PR:

Après chaque mise en production (MEP) avec la commande update -u all, les champs company_id des projects templates ayant la valeur False sont réinitialisés à la valeur par défaut, correspondant à self.env.company.

Desired behavior after PR is merged:

Après chaque MEP les company_id des projects templates ne sont plus modifiés.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
