### PR TITLE
[REF] #59952 account: make early payment discount logic easier to extend

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2535,6 +2535,11 @@ class AccountMove(models.Model):
     # -------------------------------------------------------------------------
     # EARLY PAYMENT DISCOUNT
     # -------------------------------------------------------------------------
+
+    def _is_early_payment_unmatched(self, payment_terms):
+        self.ensure_one()
+        return not (payment_terms.sudo().matched_debit_ids + payment_terms.sudo().matched_credit_ids)
+
     def _is_eligible_for_early_payment_discount(self, currency, reference_date):
         self.ensure_one()
         payment_terms = self.line_ids.filtered(lambda line: line.display_type == 'payment_term')
@@ -2546,7 +2551,7 @@ class AccountMove(models.Model):
                 or not self.invoice_date
                 or reference_date <= self.invoice_payment_term_id._get_last_discount_date(self.invoice_date)
             ) \
-            and not (payment_terms.sudo().matched_debit_ids + payment_terms.sudo().matched_credit_ids)
+            and self._is_early_payment_unmatched(payment_terms)
 
     # -------------------------------------------------------------------------
     # BUSINESS MODELS SYNCHRONIZATION

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -3213,6 +3213,10 @@ class AccountMoveLine(models.Model):
     # INSTALLMENTS
     # -------------------------------------------------------------------------
 
+    def _get_installments_data_discount(self):
+        self.ensure_one()
+        return self.discount_amount_currency, self.discount_balance
+
     def _get_installments_data(self, payment_currency=None, payment_date=None, next_payment_date=None):
         move = self.move_id
         move.ensure_one()
@@ -3245,13 +3249,14 @@ class AccountMoveLine(models.Model):
             # Early payment discount.
             # In that case, we want to report the difference of the epd and display it on the UI.
             if move._is_eligible_for_early_payment_discount(payment_currency or line.currency_id, payment_date):
+                discount_amount_currency, discount_balance = line._get_installments_data_discount()
                 installment.update({
-                    'amount_residual_currency': line.discount_amount_currency,
-                    'amount_residual': line.discount_balance,
-                    'amount_residual_currency_unsigned': -sign * line.discount_amount_currency,
-                    'amount_residual_unsigned': -sign * line.discount_balance,
-                    'discount_amount_currency': line.amount_currency - line.discount_amount_currency,
-                    'discount_amount': line.balance - line.discount_balance,
+                    'amount_residual_currency': discount_amount_currency,
+                    'amount_residual': discount_balance,
+                    'amount_residual_currency_unsigned': -sign * discount_amount_currency,
+                    'amount_residual_unsigned': -sign * discount_balance,
+                    'discount_amount_currency': line.amount_currency - discount_amount_currency,
+                    'discount_amount': line.balance - discount_balance,
                     'type': 'early_payment_discount',
                 })
                 continue


### PR DESCRIPTION
Refactored `_is_eligible_for_early_payment_discount` and related logic to allow inheritance and customization without modifying core logic.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
