### PR TITLE
[REF] #59965: refactoring default options for barcode creation

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -672,21 +672,7 @@ class IrActionsReport(models.Model):
 
     @api.model
     def barcode(self, barcode_type, value, **kwargs):
-        defaults = {
-            'width': (600, int),
-            'height': (100, int),
-            'humanreadable': (False, lambda x: bool(int(x))),
-            'quiet': (True, lambda x: bool(int(x))),
-            'mask': (None, lambda x: x),
-            'barBorder': (4, int),
-            # The QR code can have different layouts depending on the Error Correction Level
-            # See: https://en.wikipedia.org/wiki/QR_code#Error_correction
-            # Level 'L' – up to 7% damage   (default)
-            # Level 'M' – up to 15% damage  (i.e. required by l10n_ch QR bill)
-            # Level 'Q' – up to 25% damage
-            # Level 'H' – up to 30% damage
-            'barLevel': ('L', lambda x: x in ('L', 'M', 'Q', 'H') and x or 'L'),
-        }
+        defaults = self.get_barcode_default_options(barcode_type, **kwargs)
         kwargs = {k: validator(kwargs.get(k, v)) for k, (v, validator) in defaults.items()}
         kwargs['humanReadable'] = kwargs.pop('humanreadable')
         if kwargs['humanReadable']:
@@ -732,6 +718,24 @@ class IrActionsReport(models.Model):
                 raise ValueError("Cannot convert into QR code.")
             else:
                 return self.barcode('Code128', value, **kwargs)
+
+    @api.model
+    def get_barcode_default_options(self, barcode_type, **kwargs):
+        return {
+            'width': (600, int),
+            'height': (100, int),
+            'humanreadable': (False, lambda x: bool(int(x))),
+            'quiet': (True, lambda x: bool(int(x))),
+            'mask': (None, lambda x: x),
+            'barBorder': (4, int),
+            # The QR code can have different layouts depending on the Error Correction Level
+            # See: https://en.wikipedia.org/wiki/QR_code#Error_correction
+            # Level 'L' – up to 7% damage   (default)
+            # Level 'M' – up to 15% damage  (i.e. required by l10n_ch QR bill)
+            # Level 'Q' – up to 25% damage
+            # Level 'H' – up to 30% damage
+            'barLevel': ('L', lambda x: x in ('L', 'M', 'Q', 'H') and x or 'L'),
+        }
 
     @api.model
     def get_available_barcode_masks(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
The "bearers" parameter is not considered on barcode creation

Desired behavior after PR is merged:
The "bearers" parameter is now  considered on barcode creation. Set bearers="0" or bearers="1"